### PR TITLE
Erlang 17 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ deps.plt
 *.out
 *.o
 *.so
+.rebar
+erln8.config

--- a/rebar.config
+++ b/rebar.config
@@ -4,19 +4,18 @@
 
 {lib_dirs, ["deps"]}.
 
- {deps,
-  [
-   {oc_erchef, ".*",  %% use a catch all regex and peg with a tag if neded
-     {git, "git://github.com/oferrigni/oc_erchef.git", {branch, "master"}}}
-  ]}.
+{deps, [
+    {oc_erchef, ".*",
+         {git, "https://github.com/opscode/oc_erchef", {branch, "jd/1.0.0-17"}}}
+]}.
 
 %% Add dependencies that are only needed for development here. These
 %% dependencies will be hidden from upstream projects using this code
 %% as a dependency.
-%% {dev_only_deps,
-%%  [
-%%   {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}}
-%%  ]}.
+{dev_only_deps,
+ [
+    {meck, "0.8.2", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
+ ]}.
 
 %% Use edown to render a markdown version of edoc. The generated
 %% markdown can be checked in and will be browsable on github. The
@@ -27,3 +26,9 @@
 {cover_enabled, true}.
 
 {port_specs, [{"priv/fast_xs.so", ["c_src/*.c"]}]}.
+
+{erl_opts, [
+            warnings_as_errors,
+            debug_info,
+            {platform_define, "^[0-9]+", namespaced_types}
+           ]}.

--- a/src/chef_ez_reindex_direct.erl
+++ b/src/chef_ez_reindex_direct.erl
@@ -18,6 +18,10 @@
 
 -module(chef_ez_reindex_direct).
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
+
 -include_lib("oc_erchef/include/chef_types.hrl").
 -include_lib("ej/include/ej.hrl").
 

--- a/src/chef_reindex.app.src
+++ b/src/chef_reindex.app.src
@@ -8,7 +8,9 @@
                   kernel,
                   stdlib,
                   ibrowse,
-                  pooler
+                  pooler,
+                  ej,
+                  opscoderl_httpc
                  ]},
   %% uncomment if this is an active application
   {mod, { chef_reindex_app, []}},

--- a/test/fast_xs_tests.erl
+++ b/test/fast_xs_tests.erl
@@ -1,9 +1,7 @@
+%% -*- coding: utf-8 -*-
 -module(fast_xs_tests).
 
-
 -include_lib("eunit/include/eunit.hrl").
-
-
 
 expand_test() ->
         Expect = <<"k1__=__ "
@@ -27,17 +25,17 @@ predefined_test() ->
     ?assertEqual(<<"&amp;">>, fast_xs:escape(<<"&">>)),              % ampersand
     ?assertEqual(<<"&lt;">>,  fast_xs:escape(<<"<">>)),              % left angle bracket
     ?assertEqual(<<"&gt;">>,  fast_xs:escape(<<">">>)),              % right angle bracket
-    ?assertEqual(<<"&quot;">>, fast_xs:escape(<<"\"">>)).             % double quote
+    ?assertEqual(<<"&quot;">>, fast_xs:escape(<<"\"">>)).            % double quote
 
 invalid_test() ->
     ok = io:setopts([{encoding, unicode}]),
     ?assertEqual(<<"*">>, fast_xs:escape(<<"\x00">>)),               % null
     ?assertEqual(<<"*">>, fast_xs:escape(<<"\x0C">>)),               % form feed
-    ?assertEqual(<<"*">>, fast_xs:escape(<<65536>>)).           
+    ?assertEqual(<<"*">>, fast_xs:escape(<<65536>>)).
 
 iso_8859_misc_test() ->
-    ?assertEqual(<<"&#239;&#191;&#189;">>, fast_xs:escape(<<"�">>)),
-    ?assertEqual(<<"name__=__Microsoft&#194;&#174;">>, fast_xs:escape(<<"name__=__Microsoft®">>)),
+    ?assertEqual(<<"&#239;&#191;&#189;">>, fast_xs:escape(<<"�"/utf8>>)),
+    ?assertEqual(<<"name__=__Microsoft&#194;&#174;">>, fast_xs:escape(<<"name__=__Microsoft®"/utf8>>)),
     ?assertEqual(<<"Server&#174;">>, fast_xs:escape(<<"Server\xAE">>)).          % registered
 
 iso_8859_test() ->
@@ -50,6 +48,6 @@ win_1252_test() ->
 
 utf8_test() ->
     ?assertEqual(<<"&#169;">>, fast_xs:escape(<<"\x{A9}">>)),     % copy
-    ?assertEqual(<<"&#8217;">>, fast_xs:escape(<<146>>)). % right single quote
+    ?assertEqual(<<"&#8217;">>, fast_xs:escape(<<146>>)).         % right single quote
 
 


### PR DESCRIPTION
Ran into an issue with erlang changing the default way it encodes things. I think it might default binaries to UTF-16, but I can't honestly tell. Something bigger than UTF-8 for sure. Making sure the input was UTF-8 for these tests ensures that the functionality of the nif is still valid. 

An outstanding question is "does the default encoding of binary strings in erlang 17 change the overall functionality of chef_reindex?" 

ping @chef/lob and @oferrigni 